### PR TITLE
Update quick start steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,10 @@ These instructions will build and run a Docker container with a Grafana instance
 1. [Install Docker](https://docs.docker.com/get-docker/)
 2. [Obtain a Grafana Cloud API Key](https://grafana.com/docs/grafana-cloud/reference/create-api-key/),  needed to sign the plugin.
 3. [Obtain Circonus API Token](https://docs.circonus.com/circonus/integrations/api/api-tokens/), needed to connect to the hosted Circonus API.
-4. `export GRAFANA_API_KEY=<From step 2>`
-5. `export CIRCONUS_API_KEY=<From step 3>`
-7. `yarn install; yarn build; mage`
-8. `git clone https://github.com/circonus-labs/circonus-irondb-datasource/`
-9. Execute `./docker/docker-up.sh -g $GRAFANA_API_KEY -c $CIRCONUS_API_KEY`
-10. Navigate to <http://localhost:3000/> to access.
+4. `git clone https://github.com/circonus-labs/circonus-irondb-datasource/`
+5. `yarn install; yarn build; mage`
+6. Execute `./docker/docker-up.sh -g $GRAFANA_API_KEY -c $CIRCONUS_API_KEY`
+7. Navigate to <http://localhost:3000/> to access.
 
 ## Installation
 * The default location for the plugins directory is `/var/lib/grafana/plugins`, though the location may be different in your installation, see [http://docs.grafana.org/plugins/installation/](http://docs.grafana.org/plugins/installation/) for more plugin information.

--- a/README.md
+++ b/README.md
@@ -6,17 +6,6 @@ Read more about IRONdb here:
 
 [https://www.circonus.com/irondb/](https://www.circonus.com/irondb/)
 
-## Docker Quick Start
-These instructions will build and run a Docker container with a Grafana instance on port 3000. There will be a pre-configured data source connected to the hosted Circonus API with a graph and alert.
-
-1. [Install Docker](https://docs.docker.com/get-docker/)
-2. [Obtain a Grafana Cloud API Key](https://grafana.com/docs/grafana-cloud/reference/create-api-key/),  needed to sign the plugin.
-3. [Obtain Circonus API Token](https://docs.circonus.com/circonus/integrations/api/api-tokens/), needed to connect to the hosted Circonus API.
-4. `git clone https://github.com/circonus-labs/circonus-irondb-datasource/`
-5. `yarn install; yarn build; mage`
-6. Execute `./docker/docker-up.sh`
-7. Navigate to <http://localhost:3000/> to access.
-
 ## Installation
 * The default location for the plugins directory is `/var/lib/grafana/plugins`, though the location may be different in your installation, see [http://docs.grafana.org/plugins/installation/](http://docs.grafana.org/plugins/installation/) for more plugin information.
 * "Grafana now [requires backend plugins to be signed](https://grafana.com/docs/grafana/latest/installation/upgrading/#backend-plugins)." Or you can [turn off signature checks](https://grafana.com/docs/grafana/latest/plugins/plugin-signatures/#allow-unsigned-plugins). If you aren't sure which option is right for you, ask your security department. If you think you don't have one of those, congratulations, *you* are the security department. Read through the information linked above and choose the relevant section below.
@@ -51,6 +40,17 @@ These instructions will build and run a Docker container with a Grafana instance
    npx @grafana/toolkit plugin:sign --rootUrls https://example.com/grafana # Change to match the URL of your Grafana install
    sudo systemctl start grafana-server # restart if already running
    ```
+   
+   #### Docker Quick Start From Github
+These instructions will build and run a Docker container with a Grafana instance on port 3000. There will be a pre-configured data source connected to the hosted Circonus API with a graph and alert.
+
+1. [Install Docker](https://docs.docker.com/get-docker/)
+2. [Obtain a Grafana Cloud API Key](https://grafana.com/docs/grafana-cloud/reference/create-api-key/),  needed to sign the plugin.
+3. [Obtain Circonus API Token](https://docs.circonus.com/circonus/integrations/api/api-tokens/), needed to connect to the hosted Circonus API.
+4. `git clone https://github.com/circonus-labs/circonus-irondb-datasource/`
+5. `yarn install; yarn build; mage`
+6. Execute `./docker/docker-up.sh`
+7. Navigate to <http://localhost:3000/> to access.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ These instructions will build and run a Docker container with a Grafana instance
 1. [Install Docker](https://docs.docker.com/get-docker/)
 2. [Obtain a Grafana Cloud API Key](https://grafana.com/docs/grafana-cloud/reference/create-api-key/),  needed to sign the plugin.
 3. [Obtain Circonus API Token](https://docs.circonus.com/circonus/integrations/api/api-tokens/), needed to connect to the hosted Circonus API.
-4. export GRAFANA_API_KEY=<From step 2>
-5. export CIRCONUS_API_KEY=<From step 3>
-6. git clone https://github.com/circonus-labs/circonus-irondb-datasource/
-7. Execute ./docker/run-docker.sh -g $GRAFANA_API_KEY -c $CIRCONUS_API_KEY
-8. Navigate to <http://localhost:3000/> to access.
+4. `export GRAFANA_API_KEY=<From step 2>`
+5. `export CIRCONUS_API_KEY=<From step 3>`
+7. `yarn install; yarn build; mage`
+8. `git clone https://github.com/circonus-labs/circonus-irondb-datasource/`
+9. Execute `./docker/docker-up.sh -g $GRAFANA_API_KEY -c $CIRCONUS_API_KEY`
+10. Navigate to <http://localhost:3000/> to access.
 
 ## Installation
 * The default location for the plugins directory is `/var/lib/grafana/plugins`, though the location may be different in your installation, see [http://docs.grafana.org/plugins/installation/](http://docs.grafana.org/plugins/installation/) for more plugin information.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ These instructions will build and run a Docker container with a Grafana instance
 
 1. [Install Docker](https://docs.docker.com/get-docker/)
 3. [Obtain Circonus API Token](https://docs.circonus.com/circonus/integrations/api/api-tokens/), needed to connect to the hosted Circonus API.
-4. `git clone https://github.com/circonus-labs/circonus-irondb-datasource/; cd circonus-irondb-datasource`
-5. `yarn install; yarn build; mage`
-6. Execute `./docker/docker-up.sh`
-7. Navigate to <http://localhost:3000/> to access.
+4. `git clone https://github.com/circonus-labs/circonus-irondb-datasource/`
+5. `cd circonus-irondb-datasource`
+6. `yarn install; yarn build; mage`
+7. Execute `./docker/docker-up.sh` (`.\docker\docker-up.ps1` for Windows)
+8. Navigate to <http://localhost:3000/> to access.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ Read more about IRONdb here:
 These instructions will build and run a Docker container with a Grafana instance on port 3000. There will be a pre-configured data source connected to the hosted Circonus API with a graph and alert.
 
 1. [Install Docker](https://docs.docker.com/get-docker/)
-2. [Obtain a Grafana Cloud API Key](https://grafana.com/docs/grafana-cloud/reference/create-api-key/),  needed to sign the plugin.
 3. [Obtain Circonus API Token](https://docs.circonus.com/circonus/integrations/api/api-tokens/), needed to connect to the hosted Circonus API.
-4. `git clone https://github.com/circonus-labs/circonus-irondb-datasource/`
+4. `git clone https://github.com/circonus-labs/circonus-irondb-datasource/; cd circonus-irondb-datasource`
 5. `yarn install; yarn build; mage`
 6. Execute `./docker/docker-up.sh`
 7. Navigate to <http://localhost:3000/> to access.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These instructions will build and run a Docker container with a Grafana instance
 3. [Obtain Circonus API Token](https://docs.circonus.com/circonus/integrations/api/api-tokens/), needed to connect to the hosted Circonus API.
 4. `git clone https://github.com/circonus-labs/circonus-irondb-datasource/`
 5. `yarn install; yarn build; mage`
-6. Execute `./docker/docker-up.sh -g $GRAFANA_API_KEY -c $CIRCONUS_API_KEY`
+6. Execute `./docker/docker-up.sh`
 7. Navigate to <http://localhost:3000/> to access.
 
 ## Installation


### PR DESCRIPTION
We didn't include notes on building ./dist, which is no longer checked in.