### PR TITLE
CIRC-7853: Alerting backend support for CAQL min_period setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## 0.9.5
+
+ * Fixes the alerting backend so that the min_period value for generated CAQL
+ queries is correctly using the setting or default from the UI.
+
 ## 0.9.4
 
  * Fix labels for untagged metrics

--- a/pkg/irondb-backend.go
+++ b/pkg/irondb-backend.go
@@ -157,11 +157,9 @@ func (td *SampleDatasource) caqlQuery(ctx context.Context, q backend.DataQuery) 
 			if err != jsonp.KeyPathNotFoundError {
 				return nil, fmt.Errorf("unable to parse CAQL query min_period: %w", err)
 			}
-
-			minPeriod = "60"
+		} else {
+			query = "#min_period=" + minPeriod + " " + query
 		}
-
-		query = "#min_period=" + minPeriod + " " + query
 	}
 
 	log.DefaultLogger.Info("caqlQuery", "caql", query)

--- a/pkg/irondb-backend.go
+++ b/pkg/irondb-backend.go
@@ -149,7 +149,7 @@ func (td *SampleDatasource) caqlQuery(ctx context.Context, q backend.DataQuery) 
 		minPeriod, err := jsonp.GetString(q.JSON, "min_period")
 		if err != nil {
 			if err != jsonp.KeyPathNotFoundError {
-				return nil, fmt.Errorf("unable to parse CAQL query JSON: %w", err)
+				return nil, fmt.Errorf("unable to parse CAQL query min_period: %w", err)
 			}
 		}
 

--- a/pkg/irondb-backend.go
+++ b/pkg/irondb-backend.go
@@ -152,6 +152,10 @@ func (td *SampleDatasource) caqlQuery(ctx context.Context, q backend.DataQuery) 
 
 	// If needed include min_period setting in the CAQL query.
 	if !strings.HasPrefix(query, "#min_period=") {
+		// It is very important that the JSON passed into the backend by the JS
+		// correctly sets this min_period field value. It should be nothing if
+		// the query already contains #min_period=, otherwise, it should use the
+		// panel value, if set, or the datasource value if no panel value is set.
 		minPeriod, err := jsonp.GetString(q.JSON, "min_period")
 		if err != nil {
 			if err != jsonp.KeyPathNotFoundError {

--- a/pkg/irondb-backend.go
+++ b/pkg/irondb-backend.go
@@ -68,10 +68,16 @@ func (td *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 		if err != nil {
 			return nil, err
 		}
+
+		queryURL, err := jsonp.GetString(cfg, "URL")
+		if err != nil {
+			return nil, err
+		}
+
 		td.circ, err = circ.New(&circ.Config{
 			TokenKey: key,
 			TokenApp: "circonus-irondb-datasource",
-			URL:      jsonp.GetString(cfg, "URL"),
+			URL:      queryURL,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/irondb-backend.go
+++ b/pkg/irondb-backend.go
@@ -68,7 +68,11 @@ func (td *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 		if err != nil {
 			return nil, err
 		}
-		td.circ, err = circ.New(&circ.Config{TokenKey: key})
+		td.circ, err = circ.New(&circ.Config{
+			TokenKey: key,
+			TokenApp: "circonus-irondb-datasource",
+			URL:      jsonp.GetString(cfg, "URL"),
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -139,6 +143,19 @@ func (td *SampleDatasource) caqlQuery(ctx context.Context, q backend.DataQuery) 
 	if err != nil {
 		return nil, err
 	}
+
+	// If needed include min_period setting in the CAQL query.
+	if !strings.HasPrefix(query, "#min_period=") {
+		minPeriod, err := jsonp.GetString(q.JSON, "min_period")
+		if err != nil {
+			if err != jsonp.KeyPathNotFoundError {
+				return nil, fmt.Errorf("unable to parse CAQL query JSON: %w", err)
+			}
+		}
+
+		query = "#min_period=" + minPeriod + " " + query
+	}
+
 	log.DefaultLogger.Info("caqlQuery", "caql", query)
 
 	return td.caqlAPI(ctx, q, query)
@@ -272,6 +289,6 @@ func newDataSourceInstance(setting backend.DataSourceInstanceSettings) (instance
 }
 
 func (s *instanceSettings) Dispose() {
-	// Called before creatinga a new instance to allow plugin authors
+	// Called before creating a new instance to allow plugin authors
 	// to cleanup.
 }

--- a/pkg/irondb-backend.go
+++ b/pkg/irondb-backend.go
@@ -158,7 +158,9 @@ func (td *SampleDatasource) caqlQuery(ctx context.Context, q backend.DataQuery) 
 				return nil, fmt.Errorf("unable to parse CAQL query min_period: %w", err)
 			}
 		} else {
-			query = "#min_period=" + minPeriod + " " + query
+			if minPeriod != "" {
+				query = "#min_period=" + minPeriod + " " + query
+			}
 		}
 	}
 

--- a/pkg/irondb-backend.go
+++ b/pkg/irondb-backend.go
@@ -157,6 +157,8 @@ func (td *SampleDatasource) caqlQuery(ctx context.Context, q backend.DataQuery) 
 			if err != jsonp.KeyPathNotFoundError {
 				return nil, fmt.Errorf("unable to parse CAQL query min_period: %w", err)
 			}
+
+			minPeriod = "60"
 		}
 
 		query = "#min_period=" + minPeriod + " " + query

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -137,9 +137,9 @@ export class IrondbQueryCtrl extends QueryCtrl {
         this.target.alert_id = this.target.alert_id || '';
 		
         // It is very important that the JSON passed into the backend here
-		// correctly sets this min_period field value. It should be nothing if
-		// the query already contains #min_period=, otherwise, it should use the
-		// panel value, if set, or the datasource value if no panel value is set.
+        // correctly sets this min_period field value. It should be nothing if
+        // the query already contains #min_period=, otherwise, it should use the
+        // panel value, if set, or the datasource value if no panel value is set.
         this.target.min_period =
             this.target.min_period || (this.hasCAQLMinPeriod() ? this.datasource.caqlMinPeriod : '');
         this.queryModel = new IrondbQuery(this.datasource, this.target, templateSrv);

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -135,6 +135,11 @@ export class IrondbQueryCtrl extends QueryCtrl {
         this.target.local_filter_match = this.target.local_filter_match || 'all';
         this.target.alert_count_query_type = this.target.alert_count_query_type || 'instant';
         this.target.alert_id = this.target.alert_id || '';
+		
+        // It is very important that the JSON passed into the backend here
+		// correctly sets this min_period field value. It should be nothing if
+		// the query already contains #min_period=, otherwise, it should use the
+		// panel value, if set, or the datasource value if no panel value is set.
         this.target.min_period =
             this.target.min_period || (this.hasCAQLMinPeriod() ? this.datasource.caqlMinPeriod : '');
         this.queryModel = new IrondbQuery(this.datasource, this.target, templateSrv);

--- a/src/query_ctrl.ts
+++ b/src/query_ctrl.ts
@@ -135,7 +135,7 @@ export class IrondbQueryCtrl extends QueryCtrl {
         this.target.local_filter_match = this.target.local_filter_match || 'all';
         this.target.alert_count_query_type = this.target.alert_count_query_type || 'instant';
         this.target.alert_id = this.target.alert_id || '';
-		
+
         // It is very important that the JSON passed into the backend here
         // correctly sets this min_period field value. It should be nothing if
         // the query already contains #min_period=, otherwise, it should use the


### PR DESCRIPTION
 * Fixes the alerting backend so that the min_period value for generated CAQL queries is correctly using the setting or default from the UI.