### PR TITLE
CIRC-7918: Improve logging in the alerting backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## 0.9.6
 
+ * Corrects an issue caused by grafana not including the URL for the data source
+ in the configuration JSON.
  * Improves the logging performed by the IRONdb alerting back end. Errors
  parsing JSON passed to the back end will now log better descriptions of the
  problem along with the erroneous JSON.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## 0.9.6
+
+ * Improves the logging performed by the IRONdb alerting back end. Errors
+ parsing JSON passed to the back end will now log better descriptions of the
+ problem along with the erroneous JSON.
+
 ## 0.9.5
 
  * Fixes the alerting backend so that the min_period value for generated CAQL

--- a/pkg/irondb-backend.go
+++ b/pkg/irondb-backend.go
@@ -57,8 +57,8 @@ func (td *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 		cfg := req.PluginContext.DataSourceInstanceSettings.JSONData
 		dbType, err := jsonp.GetString(cfg, "irondbType")
 		if err != nil {
-			log.DefaultLogger.Error("key irondbType missing from configuration JSON: %s", err.Error())
-			log.DefaultLogger.Error("invalid configuration JSON: %s", string(cfg))
+			log.DefaultLogger.Error("key irondbType missing from configuration JSON",
+				"error", err, "config", string(cfg))
 			return nil, fmt.Errorf("irondbType missing from configuration JSON: %w", err)
 		}
 
@@ -69,15 +69,15 @@ func (td *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 
 		key, err := jsonp.GetString(cfg, "apiToken")
 		if err != nil {
-			log.DefaultLogger.Error("key apiToken missing from configuration JSON: %s", err.Error())
-			log.DefaultLogger.Error("invalid configuration JSON: %s", string(cfg))
+			log.DefaultLogger.Error("key apiToken missing from configuration JSON",
+				"error", err, "config", string(cfg))
 			return nil, fmt.Errorf("apiToken missing from configuration JSON: %w", err)
 		}
 
 		queryURL, err := jsonp.GetString(cfg, "URL")
 		if err != nil {
-			log.DefaultLogger.Error("key URL missing from configuration JSON: %s", err.Error())
-			log.DefaultLogger.Error("invalid configuration JSON: %s", string(cfg))
+			log.DefaultLogger.Error("key URL missing from configuration JSON",
+				"error", err, "config", string(cfg))
 			return nil, fmt.Errorf("URL missing from configuration JSON: %w", err)
 		}
 
@@ -87,7 +87,8 @@ func (td *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 			URL:      queryURL,
 		})
 		if err != nil {
-			log.DefaultLogger.Error("unable to create circonus go-apiclient: %s", err.Error())
+			log.DefaultLogger.Error("unable to create circonus go-apiclient",
+				"error", err.Error())
 			return nil, fmt.Errorf("unable to create circonus go-apiclient: %w", err)
 		}
 
@@ -105,8 +106,8 @@ func (td *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 	for _, q := range req.Queries {
 		qtype, err := jsonp.GetString(q.JSON, "querytype")
 		if err != nil {
-			log.DefaultLogger.Error("key querytype missing from query JSON: %s", err.Error())
-			log.DefaultLogger.Error("invalid query JSON: %s", string(q.JSON))
+			log.DefaultLogger.Error("key querytype missing from query JSON",
+				"error", err, "query", string(q.JSON))
 			return nil, fmt.Errorf("querytype missing from query JSON: %w", err)
 		}
 
@@ -115,19 +116,20 @@ func (td *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 		case "caql":
 			response, err = td.caqlQuery(ctx, q)
 			if err != nil {
-				log.DefaultLogger.Error("unable to execute CAQL query: %s", err.Error())
-				log.DefaultLogger.Error("error in CAQL query: %s", q)
+				log.DefaultLogger.Error("unable to execute CAQL query",
+					"error", err, "query", q)
 				return nil, fmt.Errorf("unable to execute CAQL query: %w", err)
 			}
 		case "basic":
 			response, err = td.basicQuery(ctx, q)
 			if err != nil {
-				log.DefaultLogger.Error("unable to execute basic query: %s", err.Error())
-				log.DefaultLogger.Error("error in basic query: %s", q)
+				log.DefaultLogger.Error("unable to execute basic query",
+					"error", err, "query", q)
 				return nil, fmt.Errorf("unable to execute basic query: %w", err)
 			}
 		default:
-			log.DefaultLogger.Error("unsupported query type %s, try (caql, basic)", qtype)
+			log.DefaultLogger.Error("unsupported query type, try (caql, basic)",
+				"qtype", qtype)
 			return nil, fmt.Errorf("unsupported query type %s, try (caql, basic)", qtype)
 		}
 		rv.Responses[q.RefID] = *response
@@ -143,19 +145,20 @@ func (td *SampleDatasource) query(ctx context.Context, query backend.DataQuery) 
 func (td *SampleDatasource) basicQuery(ctx context.Context, q backend.DataQuery) (*backend.DataResponse, error) {
 	basic, err := jsonp.GetString(q.JSON, "query")
 	if err != nil {
-		log.DefaultLogger.Error("key query missing from basic query: %s", err.Error())
+		log.DefaultLogger.Error("key query missing from basic query",
+			"error", err, "query", string(q.JSON))
 		return nil, fmt.Errorf("key query missing from basic query: %w", err)
 	}
 
 	iq := IrondbQuery{Basic: basic}
 	err = iq.ParseBasic()
 	if err != nil {
-		log.DefaultLogger.Error("unable to parse basic query: %s", err.Error())
+		log.DefaultLogger.Error("unable to parse basic query", "error", err)
 		return nil, fmt.Errorf("unable to parse basic query: %w", err)
 	}
 	query, err := iq.ToCaql()
 	if err != nil {
-		log.DefaultLogger.Error("unable to convert basic query to CAQL: %s", err.Error())
+		log.DefaultLogger.Error("unable to convert basic query to CAQL", "error", err)
 		return nil, fmt.Errorf("unable to convert basic query to CAQL: %w", err)
 	}
 
@@ -165,7 +168,8 @@ func (td *SampleDatasource) basicQuery(ctx context.Context, q backend.DataQuery)
 func (td *SampleDatasource) caqlQuery(ctx context.Context, q backend.DataQuery) (*backend.DataResponse, error) {
 	query, err := jsonp.GetString(q.JSON, "query")
 	if err != nil {
-		log.DefaultLogger.Error("key query missing from CAQL query: %s", err.Error())
+		log.DefaultLogger.Error("key query missing from CAQL query",
+			"error", err)
 		return nil, fmt.Errorf("key query missing from CAQL query: %w", err)
 	}
 
@@ -178,7 +182,8 @@ func (td *SampleDatasource) caqlQuery(ctx context.Context, q backend.DataQuery) 
 		minPeriod, err := jsonp.GetString(q.JSON, "min_period")
 		if err != nil {
 			if err != jsonp.KeyPathNotFoundError {
-				log.DefaultLogger.Error("unable to parse CAQL query min_period: %s", err.Error())
+				log.DefaultLogger.Error("unable to parse CAQL query min_period",
+					"error", err)
 				return nil, fmt.Errorf("unable to parse CAQL query min_period: %w", err)
 			}
 		} else {
@@ -235,20 +240,20 @@ func (td *SampleDatasource) caqlAPI(_ context.Context, q backend.DataQuery, quer
 
 	respdata, err := td.circ.Get(path.String())
 	if err != nil {
-		log.DefaultLogger.Error("error returned from circonus API: %s", err.Error())
-		log.DefaultLogger.Error("error in circonus API request: %s", path.String())
+		log.DefaultLogger.Error("error returned from circonus api",
+			"error", err, "request", path.String())
 		return nil, fmt.Errorf("error returned from circonus API: %w", err)
 	}
 
 	var resp DF4Response
 	if err := json.Unmarshal(respdata, &resp); err != nil {
-		log.DefaultLogger.Error("unable to unmarshal response data: %s", err.Error())
-		log.DefaultLogger.Error("error in response data: %s", string(respdata))
+		log.DefaultLogger.Error("unable to unmarshal response data",
+			"error", err, "response", string(respdata))
 		return nil, fmt.Errorf("unable to unmarshal response data: %w", err)
 	}
 
 	if resp.Version != "DF4" {
-		log.DefaultLogger.Error("invalid response version (%s)", resp.Version)
+		log.DefaultLogger.Error("invalid response version", "version", resp.Version)
 		return nil, fmt.Errorf("invalid response version (%s)", resp.Version)
 	}
 

--- a/pkg/irondb-backend.go
+++ b/pkg/irondb-backend.go
@@ -101,9 +101,11 @@ func (td *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 	for _, q := range req.Queries {
 		qtype, err := jsonp.GetString(q.JSON, "querytype")
 		if err != nil {
-			log.DefaultLogger.Error("key querytype missing from query JSON",
-				"error", err, "query", string(q.JSON))
-			return nil, fmt.Errorf("querytype missing from query JSON: %w", err)
+			log.DefaultLogger.Error("key querytype missing from query JSON "+
+				"- non-IRONdb dashboard pointed at datasource?",
+				"error", err, "query", string(q.JSON), "ref_id", q.RefID)
+			return nil, fmt.Errorf("querytype missing from query JSON: %w "+
+				"- non-IRONdb dashboard pointed at datasource?", err)
 		}
 
 		var response *backend.DataResponse

--- a/pkg/irondb-backend.go
+++ b/pkg/irondb-backend.go
@@ -74,12 +74,7 @@ func (td *SampleDatasource) QueryData(ctx context.Context, req *backend.QueryDat
 			return nil, fmt.Errorf("apiToken missing from configuration JSON: %w", err)
 		}
 
-		queryURL, err := jsonp.GetString(cfg, "URL")
-		if err != nil {
-			log.DefaultLogger.Error("key URL missing from configuration JSON",
-				"error", err, "config", string(cfg))
-			return nil, fmt.Errorf("URL missing from configuration JSON: %w", err)
-		}
+		queryURL := req.PluginContext.DataSourceInstanceSettings.URL
 
 		td.circ, err = circ.New(&circ.Config{
 			TokenKey: key,


### PR DESCRIPTION
* Improves the logging performed by the IRONdb alerting back end. Errors parsing JSON passed to the back end will now log better descriptions of the problem along with the erroneous JSON.
* Corrects an issue caused by grafana not including the URL for the data source in the configuration JSON.