### PR TITLE
Update GitHub release action version of Go to 1.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.17"
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
* Updates the release action to use the latest version of go to support building arm64 Darwin artifacts.