### PR TITLE
Bumping version to make a release with the new release process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "circonus-irondb-datasource",
-    "version": "0.9.11",
+    "version": "0.9.12",
     "description": "IRONdb Data Source for Grafana.",
     "scripts": {
         "build": "grafana-toolkit plugin:build",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -21,8 +21,8 @@
             { "name": "Project site", "url": "https://www.circonus.com/irondb/" },
             { "name": "License", "url": "https://github.com/circonus-labs/circonusllhist/blob/master/LICENSE" }
         ],
-        "version": "0.9.11",
-        "updated": "2021-12-07"
+        "version": "0.9.12",
+        "updated": "2022-03-25"
     },
 
     "dependencies": {


### PR DESCRIPTION
@dhaifley the Github Actions CI process is already updated, I'm just looking to generate a new release version: it looks like we do this by bumping the package.json number. Let me know if I've missed something.